### PR TITLE
Broaden string used to identify unique jobs

### DIFF
--- a/licenseLevel.py
+++ b/licenseLevel.py
@@ -27,7 +27,7 @@ class UsageLine(object):
     @property
     def jobId(self):
         "Extract unique job Id from raw usage line"
-        m = re.search('\(.+\)', self.line)
+        m = re.match('.+ using', self.line)
         if m:
             return m.group(0)
         return ''

--- a/licenseLevel_plugin.py
+++ b/licenseLevel_plugin.py
@@ -11,7 +11,7 @@ import abaqusGui
 from kernelAccess import session
 import sys
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 # List of Abaqus features to report. Note: license trigram must be the first word
 features = (


### PR DESCRIPTION
Bug fix: v1.1.0 was matching all jobs run on the same computer